### PR TITLE
Bugfix: changed punkt to comma in Console.Writeline in consolemenuhan…

### DIFF
--- a/HenriksHobbyLager/UI/ConsoleMenuHandler.cs
+++ b/HenriksHobbyLager/UI/ConsoleMenuHandler.cs
@@ -81,7 +81,7 @@ namespace HenriksHobbyLager.UI
             decimal price;
             while (!decimal.TryParse(Console.ReadLine(), out price))
             {
-                Console.WriteLine("Ogiltigt pris! Använd punkt istället för komma.");
+                Console.WriteLine("Ogiltigt pris! Använd komma istället för punkt.");
                 Console.Write("Pris: ");
             }
 


### PR DESCRIPTION
…dler

## Summary by Sourcery

Bug Fixes:
- Korrigera felmeddelandet i konsolmenyhanteraren för att instruera användare att använda ett kommatecken istället för en punkt för decimalinmatning.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the error message in the console menu handler to instruct users to use a comma instead of a period for decimal input.

</details>